### PR TITLE
fix function call after wayland update

### DIFF
--- a/xpaste
+++ b/xpaste
@@ -377,7 +377,7 @@ class X11Paste(object):
     def paste_into(self, window):
         "Paste the text into window by faking key presses."
         # print('paste into', window)
-        for event in X11EventGenerator(self.display, window).from_text(
+        for event in X11EventGenerator(self.display, window).from_keysyms(
                 self._buffer):
             # I'm not entirely sure how much we want to sleep here. But
             # with enough sleep and window.display.flush() we can


### PR DESCRIPTION
Currently, xpaste fails on `x11`due to a function name change:
```
xpaste
| xpaste allows you to paste text into windows that fail to
| work with the X11 selection buffers, like some Java apps.
|
| Example invocation: xsel -b | xpaste
| Go to misbehaving application: <press enter>
|
| Please type text to paste on stdin; end with [CTRL+D]
test
|
| Focus on the destination window to paste into and press
| [Enter] or abort with [CTRL+C].
Traceback (most recent call last):
  File "/nix/store/kb823fzy3l232389zlnhi6k6ajb94iqw-xpaste-1.5/bin/.xpaste-wrapped", line 596, in <module>
    main()
  File "/nix/store/kb823fzy3l232389zlnhi6k6ajb94iqw-xpaste-1.5/bin/.xpaste-wrapped", line 590, in main
    xpaste.paste_into(xpaste.get_current_window())
  File "/nix/store/kb823fzy3l232389zlnhi6k6ajb94iqw-xpaste-1.5/bin/.xpaste-wrapped", line 381, in paste_into
    for event in X11EventGenerator(self.display, window).from_text(
AttributeError: 'X11EventGenerator' object has no attribute 'from_text'
```
This PR fixes it